### PR TITLE
arrow: disable adb auth on eng build

### DIFF
--- a/config/props.mk
+++ b/config/props.mk
@@ -56,7 +56,10 @@ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     net.tethering.noprovisioning=true
 
+ifeq ($(TARGET_BUILD_VARIANT),eng)
+# Disable ADB authentication
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.adb.secure=0
+else
 # Enable ADB authentication
-ifneq ($(TARGET_BUILD_VARIANT),eng)
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.adb.secure=1
 endif


### PR DESCRIPTION
We have to set ro.adb.secure to 0 on eng builds to get access.

Change-Id: Ie128f78c52c2f46b0a26d57eeed6a186aa7d9b67